### PR TITLE
Add vanilla implementation for FlexCredit on the Credit side

### DIFF
--- a/contracts/credit/BaseCreditStorage.sol
+++ b/contracts/credit/BaseCreditStorage.sol
@@ -33,6 +33,9 @@ contract BaseCreditStorage {
     bytes32[] public activeCreditsHash;
     bytes32[] public overdueCreditsHash;
 
+    uint256 numOfBorrowers;
+    bytes32 firstCreditHash;
+
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.

--- a/contracts/credit/interfaces/IFlexCredit.sol
+++ b/contracts/credit/interfaces/IFlexCredit.sol
@@ -3,6 +3,6 @@ pragma solidity ^0.8.0;
 import {CreditConfig} from "../CreditStructs.sol";
 import {CalendarUnit} from "../../SharedDefs.sol";
 
-interface IFlexCreditWithdrawal {
-    function requestPrincipalWithdrawal(uint256 amount) external returns (bool availability);
+interface IFlexCredit {
+    function requestEarlyPrincipalWithdrawal(uint96 amount) external returns (bool availability);
 }


### PR DESCRIPTION
It is a vanilla implementation. The caller (on the pool or Epoch Manager side) has to call requestEarlyPrincipalWithdrawal(uint96) in the pay period when the extra principal is due. We shall enhance the implementation to be able to record when the extra principal is due and apply accordingly when generate the bill so that the caller does not have to manage the timing. 

CC: @bin-57blocks 