### PR TITLE
Cosmetic changes

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -261,10 +261,7 @@ contract Pool is PoolConfigCache, IPool {
         }
     }
 
-    /**
-     * @notice Gets all the reserved assets for first loss covers. PoolSafe uses this function to reserve
-     * the balance of first loss covers
-     */
+    /// @inheritdoc IPool
     function getReservedAssetsForFirstLossCovers() external view returns (uint256 reservedAssets) {
         uint256 len = _firstLossCovers.length;
         for (uint256 i; i < len; i++) {
@@ -529,10 +526,7 @@ contract Pool is PoolConfigCache, IPool {
         return _firstLossCovers;
     }
 
-    /**
-     * @notice Gets the available cap of specified first loss cover including reserved profit and loss recovery
-     * PoolFeeManager uses this function to invest available liquidity of fees in first loss cover
-     */
+    /// @inheritdoc IPool
     function getFirstLossCoverAvailableCap(
         address coverAddress,
         uint256 poolAssets

--- a/contracts/PoolFeeManager.sol
+++ b/contracts/PoolFeeManager.sol
@@ -142,9 +142,7 @@ contract PoolFeeManager is PoolConfigCache, IPoolFeeManager {
         return _accruedIncomes;
     }
 
-    /**
-     * @notice Gets total available incomes, PoolSafe uses this function to reserve the balance of fees
-     */
+    /// @inheritdoc IPoolFeeManager
     function getTotalAvailableFees() public view returns (uint256) {
         AccruedIncomes memory incomes = _getAvailableIncomes();
         return incomes.protocolIncome + incomes.poolOwnerIncome + incomes.eaIncome;
@@ -185,13 +183,13 @@ contract PoolFeeManager is PoolConfigCache, IPoolFeeManager {
     /**
      * @notice PoolOwner can call this function to know if there are some available fees to be able to invested in FirstLossCover.
      */
-    function getAvailableFeesToInvestInFirestLossCover() external view returns (uint256 fees) {
+    function getAvailableFeesToInvestInFirstLossCover() external view returns (uint256 fees) {
         (fees, ) = _getAvailableFeesToInvestInFirstLossCover(pool.totalAssets());
     }
 
     /**
      * @notice PoolOwner calls this function to invest available fees in FirstLossCover
-     * while getAvailableFeesToInvestInFirestLossCover returns a positive value.
+     * while getAvailableFeesToInvestInFirstLossCover returns a positive value.
      */
     function investFeesInFirstLossCover() external {
         poolConfig.onlyPoolOwner(msg.sender);

--- a/contracts/PoolSafe.sol
+++ b/contracts/PoolSafe.sol
@@ -57,10 +57,7 @@ contract PoolSafe is PoolConfigCache, IPoolSafe {
         underlyingToken.transfer(to, amount);
     }
 
-    /**
-     * @notice Gets the total available underlying tokens in the pool
-     * @return liquidity the quantity of underlying tokens in the pool
-     */
+    /// @inheritdoc IPoolSafe
     function getPoolLiquidity() external view virtual returns (uint256 liquidity) {
         uint256 reserved = pool.getReservedAssetsForFirstLossCovers();
         reserved += poolFeeManager.getTotalAvailableFees();
@@ -68,18 +65,12 @@ contract PoolSafe is PoolConfigCache, IPoolSafe {
         liquidity = balance > reserved ? balance - reserved : 0;
     }
 
-    /**
-     * @notice Gets total available balance of pool safe. Pool calls this function for profit and loss recoevery cases.
-     */
+    /// @inheritdoc IPoolSafe
     function totalLiquidity() external view returns (uint256 liquidity) {
         liquidity = underlyingToken.balanceOf(address(this));
     }
 
-    /**
-     * @notice Gets total available balance of admin fees. PoolFeeManager calls this function to
-     * 1. invest in FirstLossCover if there is still room.
-     * 2. withdraw by admins
-     */
+    /// @inheritdoc IPoolSafe
     function getAvailableLiquidityForFees() external view returns (uint256 liquidity) {
         uint256 balance = underlyingToken.balanceOf(address(this));
         uint256 reserved = pool.getReservedAssetsForFirstLossCovers();

--- a/contracts/interfaces/IFirstLossCover.sol
+++ b/contracts/interfaces/IFirstLossCover.sol
@@ -12,15 +12,38 @@ interface IFirstLossCover {
     function depositCover(uint256 assets) external returns (uint256 shares);
 
     /**
-     * @notice Withdraws excessive assets from the first loss cover.
-     * The remaining assets should meet the requirements specified by poolCapCoverageInBps and poolValueCoverageInBps.
+     * @notice Adds the cover by pool contracts, PoolFeeManager will call it to deposit fees of
+     * protocol owner, pool owner and/or EA.
+     */
+    function depositCoverFor(uint256 assets, address receiver) external returns (uint256 shares);
+
+    /**
+     * @notice Adds to the cover using its profit.
+     * @dev Only pool can call this function
+     */
+    function addCoverAssets(uint256 assets) external;
+
+    /**
+     * @notice Cover provider redeems from the pool
+     * @param shares the number of shares to be redeemed
+     * @param receiver the address to receive the redemption assets
+     * @dev Anyone can call this function, but they will have to burn their own shares
      */
     function redeemCover(uint256 shares, address receiver) external returns (uint256 assets);
 
-    function addCoverAssets(uint256 assets) external;
-
+    /**
+     * @notice Applies loss against the first loss cover
+     * @param loss the loss amount to be covered by the loss cover or reported as default
+     * @return remainingLoss the remaining loss after applying this cover
+     */
     function coverLoss(uint256 loss) external returns (uint256 remainingLoss);
 
+    /**
+     * @notice Applies recovered amount to this first loss cover
+     * @param recovery the recovery amount available for distribution to this cover
+     * and other covers that are more junior than this one.
+     * @dev Only pool contract tied with the cover can call this function.
+     */
     function recoverLoss(uint256 recovery) external;
 
     function totalAssets() external view returns (uint256);
@@ -32,6 +55,4 @@ interface IFirstLossCover {
     ) external view returns (uint256 remainingRecovery, uint256 recoveredAmount);
 
     function isSufficient(address account) external view returns (bool sufficient);
-
-    function depositCoverFor(uint256 assets, address receiver) external returns (uint256 shares);
 }

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -42,8 +42,16 @@ interface IPool {
 
     function readyForFirstLossCoverWithdrawal() external view returns (bool ready);
 
+    /**
+     * @notice Gets all the reserved assets for first loss covers. PoolSafe uses this function to reserve
+     * the balance of first loss covers
+     */
     function getReservedAssetsForFirstLossCovers() external view returns (uint256 reservedAssets);
 
+    /**
+     * @notice Gets the available cap of specified first loss cover including reserved profit and loss recovery
+     * PoolFeeManager uses this function to invest available liquidity of fees in first loss cover
+     */
     function getFirstLossCoverAvailableCap(
         address coverAddress,
         uint256 poolAssets

--- a/contracts/interfaces/IPoolFeeManager.sol
+++ b/contracts/interfaces/IPoolFeeManager.sol
@@ -28,5 +28,8 @@ interface IPoolFeeManager {
             uint256 eaWithdrawable
         );
 
+    /**
+     * @notice Gets total available incomes, PoolSafe uses this function to reserve the balance of fees
+     */
     function getTotalAvailableFees() external view returns (uint256);
 }

--- a/contracts/interfaces/IPoolSafe.sol
+++ b/contracts/interfaces/IPoolSafe.sol
@@ -20,11 +20,23 @@ interface IPoolSafe {
      */
     function withdraw(address to, uint256 amount) external;
 
-    function totalLiquidity() external view returns (uint256 liquidity);
-
-    function getAvailableLiquidityForFees() external view returns (uint256 liquidity);
-
+    /**
+     * @notice Gets the total available underlying tokens in the pool
+     * @return liquidity the quantity of underlying tokens in the pool
+     */
     function getPoolLiquidity() external view returns (uint256 liquidity);
 
+    /**
+     * @notice Gets total available balance of pool safe. Pool calls this function for profit and loss recoevery cases.
+     */
+    function totalLiquidity() external view returns (uint256 liquidity);
+
     function setRedemptionReserve(uint256 reserve) external;
+
+    /**
+     * @notice Gets total available balance of admin fees. PoolFeeManager calls this function to
+     * 1. invest in FirstLossCover if there is still room.
+     * 2. withdraw by admins
+     */
+    function getAvailableLiquidityForFees() external view returns (uint256 liquidity);
 }


### PR DESCRIPTION
1. Move detailed docstring to the interface where applicable, and let implementation contracts inherit the docstrings.
2. Fix typos.
3. Add more comments.
4. Import individual members instead of the entire file, per compiler warnings.