### PR TITLE
Allow pool safe to transfer funds from the first loss cover contract

### DIFF
--- a/contracts/FirstLossCover.sol
+++ b/contracts/FirstLossCover.sol
@@ -251,7 +251,7 @@ contract FirstLossCover is
         address oldUnderlyingToken,
         address newUnderlyingToken
     ) internal {
-        if (oldPoolSafe == newPoolSafe & oldUnderlyingToken == newUnderlyingToken) {
+        if (oldPoolSafe == newPoolSafe && oldUnderlyingToken == newUnderlyingToken) {
             // No need to do anything if none of the addresses changed.
             return;
         }


### PR DESCRIPTION
Link T-3243

When the pool suffers loss, the pool safe contract needs to transfer funds from the first loss cover contract to cover the loss, so the first loss cover contract needs to approve an allowance for the pool safe. After Looking into other major protocols, we found that if the spending contract is part of the protocol (i.e. not a third-party contract), it's common to approve a max allowance of uint256.max. This PR does exactly that by adding an allowance approval step in `_updatePoolConfigData()`.