### PR TITLE
Remove unnecessary getCreditHash() in CreditLine contract

### DIFF
--- a/contracts/credit/CreditLine.sol
+++ b/contracts/credit/CreditLine.sol
@@ -124,10 +124,4 @@ contract CreditLine is BorrowerLevelCreditConfig, ICreditLine {
         if (borrower != _creditBorrowerMap[creditHash]) revert Errors.notBorrower();
         (amountPaid, paidoff) = _makePrincipalPayment(borrower, creditHash, amount);
     }
-
-    function getCreditHash(
-        address borrower
-    ) internal view virtual override returns (bytes32 creditHash) {
-        return keccak256(abi.encode(address(this), borrower));
-    }
 }


### PR DESCRIPTION
simple change to remove a redundant getCreditHash() function in CreditLine contract. It is defined in parent contract BorrowerLevelCreditConfig already.  