### PR TITLE
Remove duplicate test utility func

### DIFF
--- a/test/BaseTest.ts
+++ b/test/BaseTest.ts
@@ -26,7 +26,7 @@ import {
     CreditRecordStruct,
 } from "../typechain-types/contracts/credit/Credit";
 import { EpochInfoStruct } from "../typechain-types/contracts/interfaces/IEpoch";
-import { getNextMonth, minBigNumber, sumBNArray, toToken } from "./TestUtils";
+import { minBigNumber, sumBNArray, toToken } from "./TestUtils";
 
 export type ProtocolContracts = [EvaluationAgentNFT, HumaConfig, MockToken];
 export type PoolContracts = [
@@ -489,14 +489,6 @@ export async function deployAndSetupPoolContracts(
         creditFeeManagerContract,
         receivableContract,
     ];
-}
-
-export function getNextDueDate(
-    lastDate: number | BN,
-    currentDate: number | BN,
-    periodDuration: number | BN,
-): number[] {
-    return getNextMonth(Number(lastDate), Number(currentDate), Number(periodDuration));
 }
 
 function calcProfitForFixedSeniorYieldPolicy(

--- a/test/CalendarTest.ts
+++ b/test/CalendarTest.ts
@@ -2,8 +2,12 @@ import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { Calendar } from "../typechain-types";
-import { getNextDueDate } from "./BaseTest";
-import { dateToTimestamp, getNextTime, mineNextBlockWithTimestamp } from "./TestUtils";
+import {
+    dateToTimestamp,
+    getNextDueDate,
+    getNextTime,
+    mineNextBlockWithTimestamp,
+} from "./TestUtils";
 
 let calendarContract: Calendar;
 

--- a/test/EpochManagerTest.ts
+++ b/test/EpochManagerTest.ts
@@ -26,10 +26,10 @@ import {
     PnLCalculator,
     deployAndSetupPoolContracts,
     deployProtocolContracts,
-    getNextDueDate,
 } from "./BaseTest";
 import {
     getFirstLossCoverInfo,
+    getNextDueDate,
     mineNextBlockWithTimestamp,
     overrideLPConfig,
     setNextBlockTimestamp,

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -58,7 +58,7 @@ export function getNextDate(
     return [date.unix(), numberOfPeriodsPassed];
 }
 
-export function getNextMonth(lastDate: number, currentDate: number, periodDuration: number) {
+export function getNextDueDate(lastDate: number, currentDate: number, periodDuration: number) {
     let date: moment.Moment;
     let numberOfPeriodsPassed = 0;
     let monthCount = 0;

--- a/test/credit/CreditLineTest.ts
+++ b/test/credit/CreditLineTest.ts
@@ -33,7 +33,7 @@ import {
 } from "../BaseTest";
 import {
     getMinFirstLossCoverRequirement,
-    getNextMonth,
+    getNextDueDate,
     getNextTime,
     getStartDateOfPeriod,
     mineNextBlockWithTimestamp,
@@ -70,7 +70,7 @@ let poolConfigContract: PoolConfig,
     creditFeeManagerContract: CreditFeeManager;
 
 function calcDefaultDate(cr: CreditRecordStructOutput, defaultPeriod: number): number {
-    let [defaultDate] = getNextMonth(
+    let [defaultDate] = getNextDueDate(
         cr.nextDueDate.toNumber(),
         cr.nextDueDate.toNumber(),
         defaultPeriod,
@@ -125,7 +125,7 @@ function calcLateCreditRecord(
     // console.log(`currentTime: ${currentTime}`);
 
     for (let i = 0; i < periodCount; i++) {
-        let [nextDueDate] = getNextMonth(
+        let [nextDueDate] = getNextDueDate(
             ncr.nextDueDate.toNumber(),
             ncr.nextDueDate.toNumber(),
             cc.periodDuration,
@@ -582,7 +582,7 @@ describe("CreditLine Test", function () {
             const nextTime = await getNextTime(3);
             await mineNextBlockWithTimestamp(nextTime);
 
-            const [nextDueDate] = getNextMonth(0, nextTime, 1);
+            const [nextDueDate] = getNextDueDate(0, nextTime, 1);
             const yieldDue = calcYield(borrowAmount, yieldInBps, nextDueDate - nextTime);
 
             const beforeBalance = await mockTokenContract.balanceOf(borrower.address);
@@ -665,7 +665,7 @@ describe("CreditLine Test", function () {
             let nextTime = await getNextTime(3);
             await mineNextBlockWithTimestamp(nextTime);
 
-            let [nextDueDate] = getNextMonth(0, nextTime, 3);
+            let [nextDueDate] = getNextDueDate(0, nextTime, 3);
             let yieldDue = calcYield(borrowAmount, yieldInBps, nextDueDate - nextTime);
 
             let userBeforeBalance = await mockTokenContract.balanceOf(borrower.address);
@@ -954,7 +954,7 @@ describe("CreditLine Test", function () {
             // move forward after grace late date
             let poolSettings = await poolConfigContract.getPoolSettings();
             let nextTime =
-                getNextMonth(
+                getNextDueDate(
                     creditRecord.nextDueDate.toNumber(),
                     creditRecord.nextDueDate.toNumber(),
                     periodDuration,
@@ -1017,7 +1017,7 @@ describe("CreditLine Test", function () {
             let lossStartPrincipal = getPrincipal(preCreditRecord);
 
             nextTime =
-                getNextMonth(
+                getNextDueDate(
                     preCreditRecord.nextDueDate.toNumber(),
                     preCreditRecord.nextDueDate.toNumber(),
                     2 * periodDuration,
@@ -1097,7 +1097,7 @@ describe("CreditLine Test", function () {
             // console.log(`accruedLoss: ${accruedLoss}, lossRate: ${lossRate}`);
 
             nextTime =
-                getNextMonth(
+                getNextDueDate(
                     preCreditRecord.nextDueDate.toNumber(),
                     preCreditRecord.nextDueDate.toNumber(),
                     3 * periodDuration,


### PR DESCRIPTION
`getNextDueDat` is a duplicate of `getNextMonth` - all the type conversions are unnecessary since all call sites are passing in `numbers` not `BigNumber`s. Also renamed `getNextMonth` to `getNextDueDate` since the current name makes no sense.