### PR TITLE
Add tests and skeletons for admin functions in BorrowerLevelCreditConfig

### DIFF
--- a/test/BaseTest.ts
+++ b/test/BaseTest.ts
@@ -78,6 +78,10 @@ const SENIOR_TRANCHE = 0;
 const JUNIOR_TRANCHE = 1;
 const DEFAULT_DECIMALS_FACTOR = BN.from(10).pow(18);
 const BP_FACTOR = BN.from(10000);
+const DAYS_IN_A_YEAR = 360;
+const DAYS_IN_A_MONTH = 30;
+const MONTHS_IN_A_YEAR = 12;
+const SECONDS_IN_A_DAY = 24 * 60 * 60;
 const SECONDS_IN_YEAR = 60 * 60 * 24 * 365;
 const MAX_SECONDS_IN_A_QUARTER = 92 * 24 * 60 * 60;
 const BORROWER_FIRST_LOSS_COVER_INDEX = 0;
@@ -88,8 +92,12 @@ export const CONSTANTS = {
     JUNIOR_TRANCHE,
     DEFAULT_DECIMALS_FACTOR,
     BP_FACTOR,
-    SECONDS_IN_YEAR,
+    DAYS_IN_A_YEAR,
+    DAYS_IN_A_MONTH,
+    MONTHS_IN_A_YEAR,
+    SECONDS_IN_A_DAY,
     MAX_SECONDS_IN_A_QUARTER,
+    SECONDS_IN_YEAR,
     BORROWER_FIRST_LOSS_COVER_INDEX,
     AFFILIATE_FIRST_LOSS_COVER_INDEX,
 };
@@ -898,7 +906,7 @@ export function checkTwoCreditRecords(
 export function checkCreditRecord(
     creditRecord: CreditRecordStruct,
     unbilledPrincipal: BN,
-    nextDueDate: number,
+    nextDueDate: BN | number,
     nextDue: BN,
     yieldDue: BN,
     missedPeriods: number,

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { BigNumber as BN } from "ethers";
+import { BigNumber as BN, Contract } from "ethers";
 import { ethers, network } from "hardhat";
 import moment from "moment";
 import { FirstLossCover, Pool, PoolConfig } from "../typechain-types";
@@ -219,4 +219,16 @@ export function minBigNumber(...values: BN[]): BN {
     return values.reduce((acc, currentValue) => {
         return acc.lt(currentValue) ? acc : currentValue;
     }, BN.from(ethers.constants.MaxUint256));
+}
+
+export async function borrowerLevelCreditHash(
+    creditContract: Contract,
+    borrower: SignerWithAddress,
+) {
+    return ethers.utils.keccak256(
+        ethers.utils.defaultAbiCoder.encode(
+            ["address", "address"],
+            [creditContract.address, await borrower.getAddress()],
+        ),
+    );
 }


### PR DESCRIPTION
Link T-3365

Since `BorrowerLevelCreditConfig` is an abstract contract, all tests are added to `CreditLine` instead. Some of the functions remain untested because they either rely on `_getDueInfo` or the updated calendar calculations, and neither of these prerequisite functions are complete yet.