### PR TITLE
Move approveBorrower() from CreditLine to BorrowerLevelCreditConfig

### DIFF
--- a/contracts/credit/CreditLine.sol
+++ b/contracts/credit/CreditLine.sol
@@ -14,52 +14,6 @@ import "hardhat/console.sol";
  * credit line as long as they stay under the approved credit limit.
  */
 contract CreditLine is BorrowerLevelCreditConfig, ICreditLine {
-    event CreditLineApproved(
-        address indexed borrower,
-        bytes32 indexed creditHash,
-        uint256 creditLimit,
-        uint16 periodDuration,
-        uint256 remainingPeriods,
-        uint256 yieldInBps,
-        uint256 committedAmount,
-        bool revolving
-    );
-
-    /// @inheritdoc ICreditLine
-    function approveBorrower(
-        address borrower,
-        uint96 creditLimit,
-        uint16 remainingPeriods,
-        uint16 yieldInBps,
-        uint96 committedAmount,
-        bool revolving
-    ) external virtual override {
-        poolConfig.onlyProtocolAndPoolOn();
-        _onlyEAServiceAccount();
-
-        bytes32 creditHash = getCreditHash(borrower);
-        _approveCredit(
-            borrower,
-            creditHash,
-            creditLimit,
-            remainingPeriods,
-            yieldInBps,
-            committedAmount,
-            revolving
-        );
-
-        emit CreditLineApproved(
-            borrower,
-            creditHash,
-            creditLimit,
-            _getCreditConfig(creditHash).periodDuration,
-            remainingPeriods,
-            yieldInBps,
-            committedAmount,
-            revolving
-        );
-    }
-
     /// @inheritdoc ICreditLine
     function drawdown(address borrower, uint256 borrowAmount) external virtual override {
         poolConfig.onlyProtocolAndPoolOn();

--- a/contracts/credit/interfaces/IBorrowerLevelCreditConfig.sol
+++ b/contracts/credit/interfaces/IBorrowerLevelCreditConfig.sol
@@ -4,6 +4,26 @@ import {CreditRecord} from "../CreditStructs.sol";
 
 interface IBorrowerLevelCreditConfig {
     /**
+     * @notice Approves the credit with the terms provided.
+     * @param borrower the borrower address
+     * @param creditLimit the credit limit of the credit line
+     * @param remainingPeriods the number of periods before the credit line expires
+     * @param yieldInBps expected yield expressed in basis points, 1% is 100, 100% is 10000
+     * @param committedAmount the credit that the borrower has committed to use. If the used credit
+     * is less than this amount, the borrower will charged yield using this amount.
+     * @param revolving indicates if the underlying credit line is revolving or not
+     * @dev only Evaluation Agent can call
+     */
+    function approveBorrower(
+        address borrower,
+        uint96 creditLimit,
+        uint16 remainingPeriods,
+        uint16 yieldInBps,
+        uint96 committedAmount,
+        bool revolving
+    ) external;
+
+    /**
      * @notice Updates the account and brings its billing status current
      * @dev If the account is defaulted, no need to update the account anymore.
      */

--- a/contracts/credit/interfaces/ICreditLine.sol
+++ b/contracts/credit/interfaces/ICreditLine.sol
@@ -4,26 +4,6 @@ import {CreditRecord} from "../CreditStructs.sol";
 
 interface ICreditLine {
     /**
-     * @notice Approves the credit with the terms provided.
-     * @param borrower the borrower address
-     * @param creditLimit the credit limit of the credit line
-     * @param remainingPeriods the number of periods before the credit line expires
-     * @param yieldInBps expected yield expressed in basis points, 1% is 100, 100% is 10000
-     * @param committedAmount the credit that the borrower has committed to use. If the used credit
-     * is less than this amount, the borrower will charged yield using this amount.
-     * @param revolving indicates if the underlying credit line is revolving or not
-     * @dev only Evaluation Agent can call
-     */
-    function approveBorrower(
-        address borrower,
-        uint96 creditLimit,
-        uint16 remainingPeriods,
-        uint16 yieldInBps,
-        uint96 committedAmount,
-        bool revolving
-    ) external;
-
-    /**
      * @notice allows the borrower to borrow against an approved credit line.
      * @param borrower hash of the credit record
      * @param borrowAmount the amount to borrow


### PR DESCRIPTION
Simple PR to move approveBorrower() to BorrowerLevelCreditConfig so that it can be shared by CreditLine, ReceivableBackedCreditLine, and any other borrower-level credit. 