### PR TITLE
Remove the last spot where maturity date is read in the contract code

### DIFF
--- a/contracts/credit/Calendar.sol
+++ b/contracts/credit/Calendar.sol
@@ -7,8 +7,6 @@ import {BokkyPooBahsDateTimeLibrary as DTL} from "./utils/BokkyPooBahsDateTimeLi
 import {PayPeriodDuration} from "./CreditStructs.sol";
 import {Errors} from "../Errors.sol";
 
-import "hardhat/console.sol";
-
 /**
  * @notice We use the 30/360 day count convention in this implementation, which treats every month as having 30 days
  * and every year as having 360 days, regardless of the actual number of days in a month/year. This is a common
@@ -145,12 +143,6 @@ contract Calendar is ICalendar {
         // a partial period or not, so push the start date to the beginning of the period
         // to simplify the calculation.
         startDate = getStartDateOfPeriod(periodDuration, startDate);
-        console.log(
-            "startDate %d, endDate %d, daysDiff %d",
-            startDate,
-            endDate,
-            getDaysDiff(startDate, endDate)
-        );
         numPeriodsPassed =
             getDaysDiff(startDate, endDate) /
             getTotalDaysInFullPeriod(periodDuration);

--- a/contracts/credit/CreditManager.sol
+++ b/contracts/credit/CreditManager.sol
@@ -49,15 +49,11 @@ abstract contract CreditManager is PoolConfigCache, CreditManagerStorage, ICredi
      * @param creditHash the credit hash
      * @param oldRemainingPeriods the number of remaining pay periods before the extension
      * @param newRemainingPeriods the number of remaining pay periods after the extension
-     * @param oldMaturityDate The maturity date before the extension.
-     * @param newMaturityDate The maturity date after the extension.
      */
     event RemainingPeriodsExtended(
         bytes32 indexed creditHash,
         uint256 oldRemainingPeriods,
         uint256 newRemainingPeriods,
-        uint256 oldMaturityDate,
-        uint256 newMaturityDate,
         address by
     );
 
@@ -213,8 +209,8 @@ abstract contract CreditManager is PoolConfigCache, CreditManagerStorage, ICredi
         }
 
         CreditConfig memory cc = getCreditConfig(creditHash);
-        // TODO How to handle the case the borrower never draws down?
-        if (cc.committedAmount > 0 && cr.remainingPeriods > 0)
+        if (cr.state != CreditState.Approved && cc.committedAmount > 0 && cr.remainingPeriods > 0)
+            // If a credit has started and has unfulfilled commitment, then don't allow it to be closed.
             revert Errors.creditLineHasUnfulfilledCommitment();
 
         // Close the credit by removing relevant record.
@@ -257,10 +253,14 @@ abstract contract CreditManager is PoolConfigCache, CreditManagerStorage, ICredi
      * to the LPs. Unfortunately, this special business consideration added more complexity
      * and cognitive load to `updateDueInfo`.
      */
-    function _refreshCredit(
-        bytes32 creditHash
-    ) internal returns (CreditRecord memory cr, DueDetail memory dd) {
-        return credit.updateDueInfo(creditHash);
+    function _refreshCredit(bytes32 creditHash) internal {
+        CreditRecord memory cr = credit.getCreditRecord(creditHash);
+        if (cr.state != CreditState.Approved && cr.state != CreditState.Deleted) {
+            // There is nothing to refresh when:
+            // 1. the credit is approved but hasn't started yet;
+            // 2. the credit has already been closed.
+            credit.updateDueInfo(creditHash);
+        }
     }
 
     /**
@@ -321,20 +321,10 @@ abstract contract CreditManager is PoolConfigCache, CreditManagerStorage, ICredi
         cr.remainingPeriods += uint16(newNumOfPeriods);
         credit.setCreditRecord(creditHash, cr);
 
-        uint256 oldMaturityDate = credit.getMaturityDate(creditHash);
-        uint256 newMaturityDate = calendar.getMaturityDate(
-            cc.periodDuration,
-            newNumOfPeriods,
-            oldMaturityDate
-        );
-        credit.setMaturityDate(creditHash, newMaturityDate);
-
         emit RemainingPeriodsExtended(
             creditHash,
             oldRemainingPeriods,
             cr.remainingPeriods,
-            oldMaturityDate,
-            newMaturityDate,
             msg.sender
         );
     }

--- a/test/credit/CreditLineTest.ts
+++ b/test/credit/CreditLineTest.ts
@@ -83,16 +83,6 @@ let poolConfigContract: PoolConfig,
     creditDueManagerContract: CreditDueManager,
     creditManagerContract: BorrowerLevelCreditManager;
 
-async function getCreditRecordSettings(): Promise<BN[]> {
-    let settings = Array<BN>();
-    let fees = await poolConfigContract.getFees();
-    settings.push(fees[0]);
-    settings.push(fees[1]);
-    settings.push(fees[2]);
-    settings.push(await poolConfigContract.getMinPrincipalRateInBps());
-    return settings;
-}
-
 function calcPrincipalDueForFullPeriods(
     unbilledPrincipal: BN,
     principalRateInBps: number,
@@ -2141,63 +2131,114 @@ describe("CreditLine Test", function () {
     });
 
     describe("refreshCredit", function () {
-        let yieldInBps = 1217;
-        let numOfPeriods = 3;
-        let committedAmount: BN;
-        let borrowAmount: BN;
+        const yieldInBps = 1217;
+        const numOfPeriods = 3;
+        let committedAmount: BN, borrowAmount: BN;
         let creditHash: string;
 
+        async function approveCredit() {
+            await creditManagerContract
+                .connect(eaServiceAccount)
+                .approveBorrower(
+                    borrower.address,
+                    toToken(100_000),
+                    numOfPeriods,
+                    yieldInBps,
+                    toToken(10_000),
+                    0,
+                    true,
+                );
+        }
+
         describe("Negative Tests", function () {
-            async function prepareForNegativeTests() {
-                await creditManagerContract
-                    .connect(eaServiceAccount)
-                    .approveBorrower(
-                        borrower.address,
-                        toToken(100_000),
-                        numOfPeriods,
-                        yieldInBps,
-                        toToken(10_000),
-                        0,
-                        true,
+            describe("If drawdown has not happened yet", function () {
+                async function prepare() {
+                    creditHash = ethers.utils.keccak256(
+                        ethers.utils.defaultAbiCoder.encode(
+                            ["address", "address"],
+                            [creditContract.address, borrower.address],
+                        ),
                     );
+                    await approveCredit();
+                }
 
-                creditHash = ethers.utils.keccak256(
-                    ethers.utils.defaultAbiCoder.encode(
-                        ["address", "address"],
-                        [creditContract.address, borrower.address],
-                    ),
-                );
+                beforeEach(async function () {
+                    await loadFixture(prepare);
+                });
 
-                borrowAmount = toToken(20_000);
-                await creditContract.connect(borrower).drawdown(borrower.address, borrowAmount);
-            }
+                it("Should not update anything", async function () {
+                    const oldCR = await creditContract.getCreditRecord(creditHash);
+                    const oldDD = await creditContract.getDueDetail(creditHash);
+                    await creditManagerContract.refreshCredit(borrower.address);
+                    checkCreditRecordsMatch(
+                        await creditContract.getCreditRecord(creditHash),
+                        oldCR,
+                    );
+                    checkDueDetailsMatch(await creditContract.getDueDetail(creditHash), oldDD);
+                });
 
-            beforeEach(async function () {
-                await loadFixture(prepareForNegativeTests);
+                it("Should not update anything if the credit is closed", async function () {
+                    await creditManagerContract
+                        .connect(eaServiceAccount)
+                        .closeCredit(borrower.getAddress());
+
+                    const oldCR = await creditContract.getCreditRecord(creditHash);
+                    const oldDD = await creditContract.getDueDetail(creditHash);
+                    await creditManagerContract.refreshCredit(borrower.address);
+                    checkCreditRecordsMatch(
+                        await creditContract.getCreditRecord(creditHash),
+                        oldCR,
+                    );
+                    checkDueDetailsMatch(await creditContract.getDueDetail(creditHash), oldDD);
+                });
             });
 
-            it("Should not update anything while current timestamp is less than next due date", async function () {
-                let creditRecord = await creditContract.getCreditRecord(creditHash);
-                await creditManagerContract.refreshCredit(borrower.address);
-                checkCreditRecordsMatch(
-                    await creditContract.getCreditRecord(creditHash),
-                    creditRecord,
-                );
+            describe("If drawdown has happened", function () {
+                async function prepare() {
+                    borrowAmount = toToken(20_000);
+                    creditHash = ethers.utils.keccak256(
+                        ethers.utils.defaultAbiCoder.encode(
+                            ["address", "address"],
+                            [creditContract.address, borrower.address],
+                        ),
+                    );
+                    await approveCredit();
+                    await creditContract
+                        .connect(borrower)
+                        .drawdown(borrower.address, borrowAmount);
+                }
+
+                beforeEach(async function () {
+                    await loadFixture(prepare);
+                });
+
+                it("Should not update anything if the bill is in the current billing cycle and is in good standing", async function () {
+                    const oldCR = await creditContract.getCreditRecord(creditHash);
+                    const oldDD = await creditContract.getDueDetail(creditHash);
+                    await creditManagerContract.refreshCredit(borrower.address);
+                    checkCreditRecordsMatch(
+                        await creditContract.getCreditRecord(creditHash),
+                        oldCR,
+                    );
+                    checkDueDetailsMatch(await creditContract.getDueDetail(creditHash), oldDD);
+                });
+
+                it("Should not update anything if the bill is in good standing and within the late payment grace period", async function () {
+                    const oldCR = await creditContract.getCreditRecord(creditHash);
+                    const refreshDate = oldCR.nextDueDate.toNumber() + 3600;
+                    await setNextBlockTimestamp(refreshDate);
+
+                    const oldDD = await creditContract.getDueDetail(creditHash);
+                    await creditManagerContract.refreshCredit(borrower.address);
+                    checkCreditRecordsMatch(
+                        await creditContract.getCreditRecord(creditHash),
+                        oldCR,
+                    );
+                    checkDueDetailsMatch(await creditContract.getDueDetail(creditHash), oldDD);
+                });
+
+                it.skip("Should not update anything if the credit state is Defaulted", async function () {});
             });
-
-            it("Should not update anything while current timestamp is greater than next due date and less than late grace period", async function () {
-                let creditRecord = await creditContract.getCreditRecord(creditHash);
-                let nextTime = creditRecord.nextDueDate.toNumber() + 3600;
-                await setNextBlockTimestamp(nextTime);
-
-                await creditManagerContract.refreshCredit(borrower.address);
-                checkCreditRecordsMatch(
-                    await creditContract.getCreditRecord(creditHash),
-                    creditRecord,
-                );
-            });
-
-            it("Should not update anything while credit state is Defaulted", async function () {});
         });
 
         describe("Without settings", function () {
@@ -2266,7 +2307,7 @@ describe("CreditLine Test", function () {
                     totalPastDue,
                     1,
                     remainingPeriods - 1,
-                    4,
+                    CreditState.Delayed,
                 );
 
                 const dueDetail = await creditContract.getDueDetail(creditHash);
@@ -2281,7 +2322,7 @@ describe("CreditLine Test", function () {
                 );
             });
 
-            it("Should update correctly again in the same period while credit state is Delayed", async function () {
+            it("Should update correctly again in the same period if the credit state is Delayed", async function () {
                 borrowAmount = toToken(20_000);
                 await creditContract.connect(borrower).drawdown(borrower.address, borrowAmount);
 
@@ -2313,7 +2354,7 @@ describe("CreditLine Test", function () {
                 checkDueDetailsMatch(await creditContract.getDueDetail(creditHash), dueDetail);
             });
 
-            it.skip("Should update correctly again in the next period while credit state is Delayed", async function () {
+            it("Should update correctly again in the next period if the credit state is Delayed", async function () {
                 borrowAmount = toToken(20_000);
                 await creditContract.connect(borrower).drawdown(borrower.address, borrowAmount);
 
@@ -2359,7 +2400,7 @@ describe("CreditLine Test", function () {
                     totalPastDue,
                     missingPeriods + 1,
                     remainingPeriods - 1,
-                    4,
+                    CreditState.Delayed,
                 );
             });
 
@@ -2413,7 +2454,7 @@ describe("CreditLine Test", function () {
                     totalPastDue,
                     remainingPeriods,
                     0,
-                    4,
+                    CreditState.Delayed,
                 );
 
                 const dueDetail = await creditContract.getDueDetail(creditHash);
@@ -2428,7 +2469,59 @@ describe("CreditLine Test", function () {
                 );
             });
 
-            it("Should update correctly for the first time after maturity date", async function () {});
+            it("Should update correctly for the first time after maturity date", async function () {
+                borrowAmount = toToken(20_000);
+                const drawdownDate = await getFutureBlockTime(2);
+                await setNextBlockTimestamp(drawdownDate);
+                await creditContract.connect(borrower).drawdown(borrower.address, borrowAmount);
+
+                const cc = await creditManagerContract.getCreditConfig(creditHash);
+                const maturityDate = await calendarContract.getMaturityDate(
+                    cc.periodDuration,
+                    cc.numOfPeriods,
+                    drawdownDate,
+                );
+                const refreshDate = maturityDate.toNumber() + 600;
+                await setNextBlockTimestamp(refreshDate);
+
+                const oldCR = await creditContract.getCreditRecord(creditHash);
+                const expectedNextDueDate = await calendarContract.getStartDateOfNextPeriod(
+                    cc.periodDuration,
+                    refreshDate,
+                );
+
+                await expect(creditManagerContract.refreshCredit(borrower.address))
+                    .to.emit(creditContract, "BillRefreshed")
+                    .withArgs(creditHash, expectedNextDueDate, 0);
+
+                const actualCR = await creditContract.getCreditRecord(creditHash);
+                const daysPassed = await calendarContract.getDaysDiff(
+                    oldCR.nextDueDate,
+                    maturityDate,
+                );
+                const yieldPastDue = calcYield(borrowAmount, yieldInBps, daysPassed.toNumber());
+                const expectedCR = {
+                    unbilledPrincipal: BN.from(0),
+                    nextDueDate: expectedNextDueDate,
+                    nextDue: BN.from(0),
+                    yieldDue: BN.from(0),
+                    totalPastDue: borrowAmount.add(oldCR.nextDue).add(yieldPastDue),
+                    missedPeriods: cc.numOfPeriods,
+                    remainingPeriods: 0,
+                    state: CreditState.Delayed,
+                };
+                checkCreditRecordsMatch(actualCR, expectedCR);
+
+                const actualDD = await creditContract.getDueDetail(creditHash);
+                checkDueDetailsMatch(
+                    actualDD,
+                    genDueDetail({
+                        lateFeeUpdatedDate: await calendarContract.getStartOfTomorrow(),
+                        principalPastDue: borrowAmount,
+                        yieldPastDue: oldCR.yieldDue.add(yieldPastDue),
+                    }),
+                );
+            });
 
             it("Should update correctly once in the last period, and again post-maturity", async function () {
                 borrowAmount = toToken(5_000);
@@ -2696,16 +2789,182 @@ describe("CreditLine Test", function () {
                 );
             });
 
-            it("Should update correctly again in the next period when the credit state is Delayed", async function () {});
+            it("Should update correctly again in the next period if the credit state is Delayed", async function () {
+                borrowAmount = toToken(20_000);
+                await creditContract.connect(borrower).drawdown(borrower.address, borrowAmount);
 
-            it("Should update correctly for the first time after maturity date", async function () {});
+                let oldCR = await creditContract.getCreditRecord(creditHash);
+                const settings = await poolConfigContract.getPoolSettings();
+                // First refresh happens after the late payment grace period so that the bill becomes late.
+                const firstRefreshDate =
+                    oldCR.nextDueDate.toNumber() +
+                    settings.latePaymentGracePeriodInDays * CONSTANTS.SECONDS_IN_A_DAY +
+                    100;
+                await setNextBlockTimestamp(firstRefreshDate);
+                await creditManagerContract.refreshCredit(borrower.address);
+
+                oldCR = await creditContract.getCreditRecord(creditHash);
+                const oldDD = await creditContract.getDueDetail(creditHash);
+                // Second refresh happens in another period afterward.
+                const secondRefreshDate = oldCR.nextDueDate.toNumber() + 100;
+                await setNextBlockTimestamp(secondRefreshDate);
+
+                const cc = await creditManagerContract.getCreditConfig(creditHash);
+                const expectedNextDueDate = await calendarContract.getStartDateOfNextPeriod(
+                    cc.periodDuration,
+                    secondRefreshDate,
+                );
+                const daysPassed = (
+                    await calendarContract.getDaysDiff(oldCR.nextDueDate, expectedNextDueDate)
+                ).toNumber();
+                const [accruedYieldDue, committedYieldDue] = calcYieldDue(
+                    cc,
+                    borrowAmount,
+                    daysPassed,
+                    1,
+                    membershipFee,
+                );
+                const principalDue = calcPrincipalDueForFullPeriods(
+                    oldCR.unbilledPrincipal,
+                    principalRate,
+                    1,
+                );
+                const nextDue = accruedYieldDue.add(principalDue);
+
+                await expect(creditManagerContract.refreshCredit(borrower.address))
+                    .to.emit(creditContract, "BillRefreshed")
+                    .withArgs(creditHash, expectedNextDueDate, nextDue);
+
+                const expectedLateFeeUpdatedDate = await calendarContract.getStartOfTomorrow();
+                const additionalLateFee = calcYield(
+                    borrowAmount,
+                    lateFeeBps,
+                    (
+                        await calendarContract.getDaysDiff(
+                            oldDD.lateFeeUpdatedDate,
+                            expectedLateFeeUpdatedDate,
+                        )
+                    ).toNumber(),
+                );
+                const expectedTotalPastDue = oldCR.totalPastDue
+                    .add(oldCR.nextDue)
+                    .add(additionalLateFee);
+
+                const actualCR = await creditContract.getCreditRecord(creditHash);
+                checkCreditRecord(
+                    actualCR,
+                    oldCR.unbilledPrincipal.sub(principalDue),
+                    expectedNextDueDate,
+                    nextDue,
+                    accruedYieldDue,
+                    expectedTotalPastDue,
+                    oldCR.missedPeriods + 1,
+                    oldCR.remainingPeriods - 1,
+                    CreditState.Delayed,
+                );
+
+                const actualDD = await creditContract.getDueDetail(creditHash);
+                checkDueDetailsMatch(
+                    actualDD,
+                    genDueDetail({
+                        lateFeeUpdatedDate: expectedLateFeeUpdatedDate,
+                        lateFee: oldDD.lateFee.add(additionalLateFee),
+                        yieldPastDue: oldDD.yieldPastDue.add(oldCR.yieldDue),
+                        principalPastDue: oldDD.principalPastDue.add(
+                            oldCR.nextDue.sub(oldCR.yieldDue),
+                        ),
+                        accrued: accruedYieldDue,
+                        committed: committedYieldDue,
+                    }),
+                );
+            });
+
+            it("Should update correctly for the first time after maturity date", async function () {
+                borrowAmount = toToken(20_000);
+                const drawdownDate = await getFutureBlockTime(2);
+                await setNextBlockTimestamp(drawdownDate);
+                await creditContract.connect(borrower).drawdown(borrower.address, borrowAmount);
+
+                const cc = await creditManagerContract.getCreditConfig(creditHash);
+                const maturityDate = await calendarContract.getMaturityDate(
+                    cc.periodDuration,
+                    cc.numOfPeriods,
+                    drawdownDate,
+                );
+                const refreshDate = maturityDate.toNumber() + 600;
+                await setNextBlockTimestamp(refreshDate);
+
+                const oldCR = await creditContract.getCreditRecord(creditHash);
+                const expectedNextDueDate = await calendarContract.getStartDateOfNextPeriod(
+                    cc.periodDuration,
+                    refreshDate,
+                );
+
+                await expect(creditManagerContract.refreshCredit(borrower.address))
+                    .to.emit(creditContract, "BillRefreshed")
+                    .withArgs(creditHash, expectedNextDueDate, 0);
+
+                const actualCR = await creditContract.getCreditRecord(creditHash);
+                const daysPassed = await calendarContract.getDaysDiff(
+                    oldCR.nextDueDate,
+                    maturityDate,
+                );
+                const expectedYieldPastDue = calcYield(
+                    borrowAmount,
+                    yieldInBps,
+                    daysPassed.toNumber(),
+                ).add(membershipFee.mul(2));
+                const expectedLateFeeUpdatedDate = await calendarContract.getStartOfTomorrow();
+                const expectedLateFee = calcYield(
+                    borrowAmount,
+                    lateFeeBps,
+                    (
+                        await calendarContract.getDaysDiff(
+                            oldCR.nextDueDate,
+                            expectedLateFeeUpdatedDate,
+                        )
+                    ).toNumber(),
+                );
+                const expectedCR = {
+                    unbilledPrincipal: BN.from(0),
+                    nextDueDate: expectedNextDueDate,
+                    nextDue: BN.from(0),
+                    yieldDue: BN.from(0),
+                    totalPastDue: borrowAmount
+                        .add(oldCR.yieldDue)
+                        .add(expectedYieldPastDue)
+                        .add(expectedLateFee),
+                    missedPeriods: cc.numOfPeriods,
+                    remainingPeriods: 0,
+                    state: CreditState.Delayed,
+                };
+                checkCreditRecordsMatch(actualCR, expectedCR);
+
+                const actualDD = await creditContract.getDueDetail(creditHash);
+                checkDueDetailsMatch(
+                    actualDD,
+                    genDueDetail({
+                        lateFeeUpdatedDate: await calendarContract.getStartOfTomorrow(),
+                        lateFee: expectedLateFee,
+                        principalPastDue: borrowAmount,
+                        yieldPastDue: oldCR.yieldDue.add(expectedYieldPastDue),
+                    }),
+                );
+            });
 
             it("Should update correctly once in the last period, and again post-maturity", async function () {
                 borrowAmount = toToken(5_000);
+                const drawdownDate = await getFutureBlockTime(1);
+                await setNextBlockTimestamp(drawdownDate);
                 await creditContract.connect(borrower).drawdown(borrower.address, borrowAmount);
 
                 // First refresh is performed before maturity.
-                const maturityDate = await creditContract.getMaturityDate(creditHash);
+                const cc = await creditManagerContract.getCreditConfig(creditHash);
+                const maturityDate = await calendarContract.getMaturityDate(
+                    cc.periodDuration,
+                    cc.numOfPeriods,
+                    drawdownDate,
+                );
                 const firstRefreshDate = maturityDate.toNumber() - 600;
                 await setNextBlockTimestamp(firstRefreshDate);
                 await creditManagerContract.refreshCredit(borrower.address);
@@ -2714,7 +2973,6 @@ describe("CreditLine Test", function () {
                 const secondRefreshDate = maturityDate.toNumber() + 600;
                 await setNextBlockTimestamp(secondRefreshDate);
 
-                const cc = await creditManagerContract.getCreditConfig(creditHash);
                 const oldCR = await creditContract.getCreditRecord(creditHash);
                 const oldDD = await creditContract.getDueDetail(creditHash);
                 const expectedNextDueDate = await calendarContract.getStartDateOfNextPeriod(
@@ -2727,9 +2985,10 @@ describe("CreditLine Test", function () {
                     .withArgs(creditHash, expectedNextDueDate, 0);
 
                 const actualCR = await creditContract.getCreditRecord(creditHash);
+                const expectedLateFeeRefreshDate = await calendarContract.getStartOfTomorrow();
                 const daysPassed = await calendarContract.getDaysDiff(
-                    firstRefreshDate,
-                    secondRefreshDate,
+                    oldDD.lateFeeUpdatedDate,
+                    expectedLateFeeRefreshDate,
                 );
                 const additionalLateFee = calcYield(
                     borrowAmount,
@@ -2755,7 +3014,7 @@ describe("CreditLine Test", function () {
                 checkDueDetailsMatch(
                     actualDD,
                     genDueDetail({
-                        lateFeeUpdatedDate: await calendarContract.getStartOfTomorrow(),
+                        lateFeeUpdatedDate: expectedLateFeeRefreshDate,
                         lateFee: oldDD.lateFee.add(additionalLateFee),
                         principalPastDue: borrowAmount,
                         yieldPastDue: oldDD.yieldPastDue.add(oldCR.yieldDue),
@@ -2923,9 +3182,6 @@ describe("CreditLine Test", function () {
                     latePaymentGracePeriodInDays,
                 );
                 let nextDueBefore = remainingPrincipalNextDue.add(remainingYieldNextDue);
-                console.log(
-                    `remaining principal next due ${remainingPrincipalNextDue}, remaining yield next due ${remainingYieldNextDue}`,
-                );
 
                 let principalDuePaid = BN.from(0),
                     yieldDuePaid = BN.from(0),
@@ -2938,7 +3194,6 @@ describe("CreditLine Test", function () {
                 let remainingPastDue = remainingPrincipalPastDue
                     .add(remainingYieldPastDue)
                     .add(remainingLateFee);
-                console.log(`Initial remaining yield past due ${remainingYieldPastDue}`);
                 if (remainingPastDue.gt(0)) {
                     if (paymentAmount.gte(remainingPastDue)) {
                         yieldPastDuePaid = remainingYieldPastDue;
@@ -3144,9 +3399,6 @@ describe("CreditLine Test", function () {
                     ).toNumber();
                 }
                 const remainingPeriods = Math.max(cr.remainingPeriods - periodsPassed, 0);
-                console.log(
-                    `periodsPassed: ${periodsPassed}, cr.remainingPeriods: ${cr.remainingPeriods}, remainingPeriods: ${remainingPeriods}`,
-                );
                 // Whether the bill is late up until payment is made.
                 const isLate =
                     cr.missedPeriods > 0 ||


### PR DESCRIPTION
Plus:
1. Update `refreshCredit` to not refresh newly-approved or closed credits. This is necessary since we no longer block refreshing credits in `updateUdeInfo`
2. Check whether the credit is in good standing before calling `updateDueInfo` in `makePrincipalPayment`, for the same reason as above
3. Add more test cases for `refreshCredit`