### PR TITLE
100% test coverage for PoolConfigCache

### DIFF
--- a/test/unit/common/PoolConfigCacheTest.ts
+++ b/test/unit/common/PoolConfigCacheTest.ts
@@ -105,6 +105,12 @@ describe("PoolConfigCache Test", function () {
         await loadFixture(prepare);
     });
 
+    it("Should not allow pool cache to be initialized twice", async function () {
+        await expect(poolSafeContract.initialize(poolConfigContract.address)).to.be.revertedWith(
+            "Initializable: contract is already initialized",
+        );
+    });
+
     it("Should not allow non-poolOwner to update pool config cache", async function () {
         await expect(
             juniorTrancheVaultContract.updatePoolConfigData(),


### PR DESCRIPTION
![Screenshot 2024-01-11 at 12 12 43 PM](https://github.com/00labs/huma-contracts-v2/assets/5438883/35118918-4ffe-45c3-a5bd-435fcf1306dd)
The current test didn't test initialize poolConfigCache twice.