### PR TITLE
Disable EA NFT transfer by throwing errors

### DIFF
--- a/contracts/common/EvaluationAgentNFT.sol
+++ b/contracts/common/EvaluationAgentNFT.sol
@@ -59,7 +59,7 @@ contract EvaluationAgentNFT is ERC721URIStorage, Ownable {
         address to,
         uint256 tokenId
     ) public virtual override(ERC721, IERC721) {
-        // Intentionally disable transfer by doing nothing.
+        revert Errors.UnsupportedFunction();
     }
 
     function safeTransferFrom(
@@ -67,7 +67,7 @@ contract EvaluationAgentNFT is ERC721URIStorage, Ownable {
         address to,
         uint256 tokenId
     ) public virtual override(ERC721, IERC721) {
-        // Intentionally disable transfer by doing nothing.
+        revert Errors.UnsupportedFunction();
     }
 
     function safeTransferFrom(
@@ -76,6 +76,6 @@ contract EvaluationAgentNFT is ERC721URIStorage, Ownable {
         uint256 tokenId,
         bytes memory data
     ) public virtual override(ERC721, IERC721) {
-        // Intentionally disable transfer by doing nothing.
+        revert Errors.UnsupportedFunction();
     }
 }

--- a/test/unit/common/EvaluationAgentNFTTest.ts
+++ b/test/unit/common/EvaluationAgentNFTTest.ts
@@ -5,12 +5,9 @@ import { ethers } from "hardhat";
 import { EvaluationAgentNFT } from "../../../typechain-types";
 
 describe("EvaluationAgentNFT Test", function () {
-    let deployer: SignerWithAddress;
-    let eaUser: SignerWithAddress;
-    let eaUser2: SignerWithAddress;
+    let deployer: SignerWithAddress, eaUser: SignerWithAddress, eaUser2: SignerWithAddress;
     let nftContract: EvaluationAgentNFT;
     let eaNFTTokenId: BigNumber;
-    let eaNFTTokenId2: BigNumber;
     const uri =
         "data:application/json;base64,eyJkZXNjcmlwdGlvbiI6ICJSZXByZXNlbnRzIHRoZSBFdmFsdWF0aW9uIEFnZW50IHRoYXQgYWltcyB0byBwcm92aWRlIGEgc2VydmljZSBmb3IgdGhlIEh1bWEgcG9vbCB0byBhcHByb3ZlZCBvciBkZWNsaW5lIHRoZSBjcmVkaXQgbGluZSBhcHBsaWNhdGlvbiIsICJuYW1lIjogIkh1bWEgRXZhbHVhdGlvbiBBZ2VudDogT25jaGFpbiBpbmNvbWUiLCAiaW1hZ2UiOiAiaHR0cHM6Ly9pcGZzLmlvL2lwZnMvUW1mMjNqa0d0eFh3aTR1NE1pTW1uS0xBOThya0dYbkYxOW5XZkxEMVM3R1hKdCIsICJhdHRyaWJ1dGVzIjogW3sidHJhaXRfdHlwZSI6ICJBVUMiLCAidmFsdWUiOiAwLjl9LCB7InRyYWl0X3R5cGUiOiAic3R5bGUiLCAidmFsdWUiOiAiYXV0b21hdGljIn0sIHsidHJhaXRfdHlwZSI6ICJuYW1lIiwgInZhbHVlIjogIk9uY2hhaW4gaW5jb21lIEVBIn0sIHsidHJhaXRfdHlwZSI6ICJzdGF0dXMiLCAidmFsdWUiOiAiYXBwcm92ZWQifV19";
 
@@ -28,41 +25,39 @@ describe("EvaluationAgentNFT Test", function () {
                 eaNFTTokenId = evt.args!.tokenId;
             }
         }
-
-        const tx2 = await nftContract.mintNFT(eaUser.address);
-        const receipt2 = await tx2.wait();
-        for (const evt of receipt2.events!) {
-            if (evt.event === "NFTGenerated") {
-                eaNFTTokenId2 = evt.args!.tokenId;
-            }
-        }
     });
 
     it("Should do nothing for all the transfer requests", async function () {
-        await nftContract.transferFrom(eaUser.address, eaUser2.address, eaNFTTokenId);
+        await expect(
+            nftContract.transferFrom(eaUser.address, eaUser2.address, eaNFTTokenId),
+        ).to.be.revertedWithCustomError(nftContract, "UnsupportedFunction");
         expect(await nftContract.ownerOf(eaNFTTokenId)).to.equal(eaUser.address);
 
-        await nftContract
-            .connect(eaUser)
-            .functions["safeTransferFrom(address,address,uint256)"](
-                eaUser.address,
-                eaUser2.address,
-                eaNFTTokenId,
-            );
+        await expect(
+            nftContract
+                .connect(eaUser)
+                .functions["safeTransferFrom(address,address,uint256)"](
+                    eaUser.address,
+                    eaUser2.address,
+                    eaNFTTokenId,
+                ),
+        ).to.be.revertedWithCustomError(nftContract, "UnsupportedFunction");
         expect(await nftContract.ownerOf(eaNFTTokenId)).to.equal(eaUser.address);
-        await nftContract
-            .connect(eaUser)
-            .functions["safeTransferFrom(address,address,uint256,bytes)"](
-                eaUser.address,
-                eaUser2.address,
-                eaNFTTokenId,
-                new Uint8Array(256),
-            );
+        await expect(
+            nftContract
+                .connect(eaUser)
+                .functions["safeTransferFrom(address,address,uint256,bytes)"](
+                    eaUser.address,
+                    eaUser2.address,
+                    eaNFTTokenId,
+                    new Uint8Array(256),
+                ),
+        ).to.be.revertedWithCustomError(nftContract, "UnsupportedFunction");
         expect(await nftContract.ownerOf(eaNFTTokenId)).to.equal(eaUser.address);
     });
 
     describe("setURI", function () {
-        it("Shall allow the owner to change URI", async function () {
+        it("Should allow the owner to change URI", async function () {
             expect(await nftContract.connect(deployer).setTokenURI(eaNFTTokenId, uri))
                 .to.emit(nftContract, "SetURI")
                 .withArgs(eaNFTTokenId, uri);
@@ -73,18 +68,19 @@ describe("EvaluationAgentNFT Test", function () {
             ).to.be.revertedWith("Ownable: caller is not the owner");
         });
     });
+
     describe("burn", function () {
-        it("Shall reject non-owner to burn it", async function () {
+        it("Should reject non-owner to burn it", async function () {
             await expect(
                 nftContract.connect(deployer).burn(eaNFTTokenId),
             ).to.be.revertedWithCustomError(nftContract, "NFTOwnerRequired");
         });
-        it("Shall allow NFT owner to burn an NFT", async function () {
-            expect(await nftContract.balanceOf(eaUser.address)).to.equal(2);
+        it("Should allow NFT owner to burn an NFT", async function () {
+            expect(await nftContract.balanceOf(eaUser.address)).to.equal(1);
             expect(await nftContract.connect(eaUser).burn(eaNFTTokenId))
                 .to.emit(nftContract, "Transfer")
                 .withArgs(eaUser.address, ethers.constants.AddressZero, eaNFTTokenId);
-            expect(await nftContract.balanceOf(eaUser.address)).to.equal(1);
+            expect(await nftContract.balanceOf(eaUser.address)).to.equal(0);
         });
     });
 });


### PR DESCRIPTION
Link T-3850

So that we are more consistent with TrancheVault and FirstLossCover.