### PR TITLE
Remove `setPoolUnderlyingToken()`

### DIFF
--- a/contracts/common/PoolConfig.sol
+++ b/contracts/common/PoolConfig.sol
@@ -397,14 +397,6 @@ contract PoolConfig is Initializable, AccessControlUpgradeable, UUPSUpgradeable 
     }
 
     /// @custom:access Only the pool owner and the Huma master admin can call this function.
-    function setPoolUnderlyingToken(address _underlyingToken) external {
-        _onlyOwnerOrHumaMasterAdmin();
-        if (_underlyingToken == address(0)) revert Errors.ZeroAddressProvided();
-        underlyingToken = _underlyingToken;
-        emit PoolUnderlyingTokenChanged(_underlyingToken, msg.sender);
-    }
-
-    /// @custom:access Only the pool owner and the Huma master admin can call this function.
     function setTranches(address _seniorTranche, address _juniorTranche) external {
         _onlyOwnerOrHumaMasterAdmin();
         if (_seniorTranche == address(0) || _juniorTranche == address(0))

--- a/test/unit/common/PoolConfigTest.ts
+++ b/test/unit/common/PoolConfigTest.ts
@@ -1322,50 +1322,6 @@ describe("PoolConfig Tests", function () {
             });
         });
 
-        describe("setPoolUnderlyingToken", function () {
-            it("Should allow the pool owner to set the underlying token", async function () {
-                await expect(
-                    poolConfigContract
-                        .connect(poolOwner)
-                        .setPoolUnderlyingToken(mockTokenContract.address),
-                )
-                    .to.emit(poolConfigContract, "PoolUnderlyingTokenChanged")
-                    .withArgs(mockTokenContract.address, poolOwner.address);
-                expect(await poolConfigContract.underlyingToken()).to.equal(
-                    mockTokenContract.address,
-                );
-            });
-
-            it("Should allow the Huma master admin to set the underlying token", async function () {
-                await expect(
-                    poolConfigContract
-                        .connect(protocolOwner)
-                        .setPoolUnderlyingToken(mockTokenContract.address),
-                )
-                    .to.emit(poolConfigContract, "PoolUnderlyingTokenChanged")
-                    .withArgs(mockTokenContract.address, protocolOwner.address);
-                expect(await poolConfigContract.underlyingToken()).to.equal(
-                    mockTokenContract.address,
-                );
-            });
-
-            it("Should reject non-owner or admin to set the underlying token", async function () {
-                await expect(
-                    poolConfigContract
-                        .connect(regularUser)
-                        .setPoolUnderlyingToken(poolOwnerTreasury.address),
-                ).to.be.revertedWithCustomError(poolConfigContract, "AdminRequired");
-            });
-
-            it("Should disallow zero address for the underlying token", async function () {
-                await expect(
-                    poolConfigContract
-                        .connect(poolOwner)
-                        .setPoolUnderlyingToken(ethers.constants.AddressZero),
-                ).to.be.revertedWithCustomError(poolConfigContract, "ZeroAddressProvided");
-            });
-        });
-
         describe("setTranches", function () {
             it("Should allow the pool owner to set the tranches", async function () {
                 await expect(


### PR DESCRIPTION
Link T-3850

If we need to swap out the underlying token of a pool, we'll close the pool and then start a new one from scratch.