### PR TITLE
Only require min deposit amount in `depositCover`

### DIFF
--- a/contracts/liquidity/FirstLossCover.sol
+++ b/contracts/liquidity/FirstLossCover.sol
@@ -134,6 +134,7 @@ contract FirstLossCover is
     function depositCover(uint256 assets) external returns (uint256 shares) {
         if (assets == 0) revert Errors.ZeroAmountProvided();
         _onlyCoverProvider(msg.sender);
+        PoolSettings memory poolSettings = poolConfig.getPoolSettings();
         if (assets < poolSettings.minDepositAmount) {
             revert Errors.DepositAmountTooLow();
         }
@@ -375,7 +376,6 @@ contract FirstLossCover is
     }
 
     function _deposit(uint256 assets, address account) internal returns (uint256 shares) {
-        PoolSettings memory poolSettings = poolConfig.getPoolSettings();
         if (assets > getAvailableCap()) {
             revert Errors.FirstLossCoverLiquidityCapExceeded();
         }

--- a/test/unit/liquidity/FirstLossCoverTest.ts
+++ b/test/unit/liquidity/FirstLossCoverTest.ts
@@ -640,16 +640,6 @@ describe("FirstLossCover Tests", function () {
                 "AuthorizedContractCallerRequired",
             );
         });
-
-        it("Should disallow deposits with amounts lower than the min requirement", async function () {
-            const poolSettings = await poolConfigContract.getPoolSettings();
-            await expect(
-                adminFirstLossCoverContract.depositCoverFor(
-                    poolSettings.minDepositAmount.sub(toToken(1)),
-                    evaluationAgent.getAddress(),
-                ),
-            ).to.be.revertedWithCustomError(adminFirstLossCoverContract, "DepositAmountTooLow");
-        });
     });
 
     describe("addCoverAssets", function () {


### PR DESCRIPTION
Do not enforce min deposit amount in `depositCoverFor()` since the function is used by the pool fee manager to deposit on behalf of pool admins when investing in first loss covers, and the amount is not guaranteed to be always greater than the min deposit amount. So let's enforce the `minDepositAmount` on proactive deposits from providers only.